### PR TITLE
Add integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,69 @@
+
+// Karma configuration
+// Generated on Tue Jan 06 2015 20:37:11 GMT-0800 (PST)
+// http://karma-runner.github.io/0.8/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['mocha', 'chai'],
+
+    // list of files / patterns to load in the browser
+    files: [
+        // dependencies
+        // JavaScript Core Libaries
+
+        // JavaScript Application Libaries
+      'dist/animorph.js',
+      'tests/*.js'
+    ],
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_ERROR,
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: false,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['ChromeNoSandbox'],
+
+    customLaunchers: {
+      ChromeNoSandbox: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true
+
+  });
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "rollup:vanilla": "rollup -c config/rollup.vanilla.js",
     "watch": "rollup -c config/rollup.vanilla.js -w",
     "watch-jquery": "rollup -c config/rollup.jquery.js -w",
-    "test": "semistandard"
+    "test": "npm-run-all --parallel test:*",
+    "test:karma": "karma start",
+    "test:lint": "semistandard",
+    "semistandard-fix": "semistandard --fix"
   },
   "repository": {
     "type": "git",
@@ -40,6 +43,10 @@
     "babel-preset-stage-0": "^6.16.0",
     "chai": "^3.5.0",
     "jsdom": "^9.6.0",
+    "karma": "^1.3.0",
+    "karma-chai": "^0.1.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-mocha": "^1.2.0",
     "mocha": "^3.1.0",
     "mocha-jsdom": "^1.1.0",
     "npm-run-all": "^3.1.0",

--- a/tests/animation.js
+++ b/tests/animation.js
@@ -1,0 +1,87 @@
+/* global describe, it, animorph, requestAnimationFrame, assert */
+
+function requestAnimationFramePromise (frames) {
+  return new Promise(function (resolve) {
+    requestAnimationFrame(function () {
+      if (frames > 1) {
+        return requestAnimationFramePromise(frames - 1).then(resolve);
+      }
+      resolve();
+    });
+  });
+}
+
+describe('DOM Tests', function () {
+  function createDemo (html, css, test) {
+    var style = document.createElement('style');
+    style.innerHTML = css;
+    var div = document.createElement('div');
+    div.innerHTML = html;
+    div.appendChild(style);
+    document.body.appendChild(div);
+    function cleanup () {
+      document.body.removeChild(div);
+    }
+    return Promise.resolve()
+      .then(function () {
+        return test();
+      })
+      .then(cleanup);
+  }
+
+  it('animorph was loaded', function () {
+    assert.equal(typeof animorph, 'object');
+    assert.equal(typeof animorph.animorph, 'function');
+  });
+
+  it('adds prepare styles without transition', function () {
+    return createDemo(
+      '<div class="demo"></div>',
+      '.am-enter { transition: 2s } .am-enter-prepare { background-color: #000 } .am-enter-active { background-color: #f00 }',
+      function () {
+        var demo = document.querySelector('.demo');
+        animorph.replaceClasses(demo);
+        return requestAnimationFramePromise().then(function () {
+          var startColor = window.getComputedStyle(demo).backgroundColor;
+          assert.equal(startColor, 'rgb(0, 0, 0)');
+        });
+      });
+  });
+
+  it('adds the prepare class before the animation starts', function () {
+    return createDemo(
+      '<div class="demo">A</div>',
+      '.am-enter { transition: 2s }',
+      function (done) {
+        var demo = document.querySelector('.demo');
+        animorph.replaceClasses(demo);
+        assert.equal(demo.className, 'demo am-enter-prepare am-enter am-animate');
+      });
+  });
+
+  it('removes the prepare class once the animation starts', function () {
+    return createDemo(
+      '<div class="demo">A</div>',
+      '.am-enter { transition: 2s }',
+      function (done) {
+        var demo = document.querySelector('.demo');
+        animorph.replaceClasses(demo);
+        return requestAnimationFramePromise(2).then(function () {
+          assert.equal(demo.className, 'demo am-enter am-animate am-enter-active');
+        });
+      });
+  });
+
+  it('removes all animorph classes after the animation ends', function () {
+    return createDemo(
+      '<div class="demo">A</div>',
+      '.am-enter { transition: 0s }',
+      function (done) {
+        var demo = document.querySelector('.demo');
+        animorph.replaceClasses(demo);
+        return requestAnimationFramePromise(2).then(function () {
+          assert.equal(demo.className, 'demo');
+        });
+      });
+  });
+});


### PR DESCRIPTION
This pull request adds karma with chrome.

`npm test` will now execute all tests in tests/animation.js in your installed chrome.

I also added the following tests:
- animorph was loaded (just checks if the global animorph object exists)
- adds prepare styles without transition 
- adds the prepare class before the animation starts
- removes the prepare class once the animation starts
- removes all animorph classes after the animation ends

This should be a solid foundation to add also tests for the morph animation and edge cases.
