### PR TITLE
Fix staggering cache-issue

### DIFF
--- a/src/vanilla.js
+++ b/src/vanilla.js
@@ -42,6 +42,7 @@ export function animorph (element, {
   }
   // Turn element from a single element or a node list or an array to an array:
   const elements = isDomElement(element) ? [element] : Array.prototype.slice.call(element);
+  const elementsCount = elements.length;
   return Promise.all(elements.map((element, animationIndex) => {
     if (!isDomElement(element)) {
       throw new Error('Element is required');
@@ -56,6 +57,7 @@ export function animorph (element, {
       addClasses,
       removeClasses,
       element,
+      elementsCount,
       target,
       operation,
       morphParent


### PR DESCRIPTION
This pull request fixes an issue related to staggering.

The problem occurred when the same DOM-nodes are animated twice, once without staggering and once with staggering. The animation would in this case stagger in both animations because the staggering-time is stored in a staggering-cache. 

This fix clears the cache for a specific group of elements (staggering-group) after the animation of the last element has completed.