### PR TITLE
add animation classes before creating cache key

### DIFF
--- a/src/utils/animation.js
+++ b/src/utils/animation.js
@@ -30,7 +30,6 @@ export function enterAnimation ({
   addClasses,
   removeClasses,
   element,
-  elementsCount,
   target,
   operation,
   animationIndex
@@ -41,7 +40,6 @@ export function enterAnimation ({
   return animation({
     namespace,
     element,
-    elementsCount,
     addClasses,
     removeClasses,
     animationIndex,
@@ -61,7 +59,6 @@ export function enterAnimation ({
 export function leaveAnimation ({
   namespace,
   element,
-  elementsCount,
   addClasses,
   removeClasses,
   animationIndex
@@ -69,7 +66,6 @@ export function leaveAnimation ({
   return animation({
     namespace,
     element,
-    elementsCount,
     addClasses,
     removeClasses,
     animationIndex,
@@ -94,7 +90,6 @@ export function morphAnimation ({
   addClasses,
   removeClasses,
   element,
-  elementsCount,
   target,
   operation,
   morphParent,
@@ -116,7 +111,6 @@ export function morphAnimation ({
       addClasses: [],
       removeClasses: [],
       element,
-      elementsCount,
       target,
       operation,
       animationIndex
@@ -126,7 +120,6 @@ export function morphAnimation ({
       addClasses,
       removeClasses,
       element: movePlaceholder,
-      elementsCount,
       morphParent,
       target: element,
       animationIndex
@@ -136,7 +129,6 @@ export function morphAnimation ({
       addClasses: [],
       removeClasses: [],
       element: leavePlaceholder,
-      elementsCount,
       animationIndex
     })
   ]).then(() => {
@@ -171,7 +163,6 @@ function moveAnimation ({
   addClasses,
   removeClasses,
   element,
-  elementsCount,
   target,
   morphParent,
   animationIndex
@@ -186,7 +177,6 @@ function moveAnimation ({
   return animation({
     namespace,
     element,
-    elementsCount,
     addClasses,
     removeClasses,
     animationIndex,
@@ -215,7 +205,6 @@ function animation ({
   addClasses,
   removeClasses,
   element,
-  elementsCount,
   animationName,
   animationIndex,
   onAnimationStart = () => {}
@@ -223,7 +212,6 @@ function animation ({
   return _startAnimation({
     namespace,
     element,
-    elementsCount,
     addClasses,
     removeClasses,
     animationName,
@@ -269,7 +257,6 @@ function _createMovePlaceholder (node, morphParent) {
 function _startAnimation ({
   namespace,
   element,
-  elementsCount,
   addClasses,
   removeClasses,
   animationIndex,
@@ -298,6 +285,8 @@ function _startAnimation ({
 /**
  * Returns a cache-key based on the class-names
  * @param {HTMLElement} node The HTML-node to receive the classes from
+ * @param {string} namespace The namespace on which to append the animationName
+ * @param {string} animationName The name of the animation (e.g. enter / leave)
  * @return {string} The key composed of the class-names of the node
  */
 function _composeCacheKey (node, namespace, animationName) {

--- a/src/utils/animation.js
+++ b/src/utils/animation.js
@@ -275,22 +275,18 @@ function _startAnimation ({
   animationIndex,
   animationName = 'enter'
 }) {
+  const cacheKey = _composeCacheKey(element, namespace, animationName);
+  const staggeringDuration = animationIndex === 0 ? 0 : _getStaggeringFromCache({element, animationIndex, animationName, namespace}, cacheKey);
+
   disableTransitions(element);
   addClass(element, `${namespace}-${animationName}-prepare`);
   addClass(element, `${namespace}-${animationName}`);
   addClass(element, `${namespace}-animate`);
 
-  const cacheKey = _composeCacheKey(element);
-  const staggeringDuration = animationIndex === 0 ? 0 : _getStaggeringFromCache({element, animationIndex, animationName, namespace}, cacheKey);
-
   return new Promise((resolve) => {
     setTimeout(resolve, staggeringDuration);
   }).then(() => forceReflow(element).then(() => {
     forceReflow(element);
-    // clear cache for animation-group when last element of this group finished
-    if (elementsCount === animationIndex + 1) {
-      delete staggeringCache[cacheKey];
-    }
     removeClass(element, `${namespace}-${animationName}-prepare`);
     addClass(element, `${namespace}-${animationName}-active`);
     addClasses.forEach((className) => addClass(element, className));
@@ -304,8 +300,9 @@ function _startAnimation ({
  * @param {HTMLElement} node The HTML-node to receive the classes from
  * @return {string} The key composed of the class-names of the node
  */
-function _composeCacheKey (node) {
+function _composeCacheKey (node, namespace, animationName) {
   var classNames = getClassNames(node);
+  classNames.push(`${namespace}-${animationName}`);
   classNames.sort();
   return classNames.join(' ');
 }

--- a/src/utils/animation.js
+++ b/src/utils/animation.js
@@ -275,12 +275,14 @@ function _startAnimation ({
   animationIndex,
   animationName = 'enter'
 }) {
-  const cacheKey = _composeCacheKey(element);
-  const staggeringDuration = animationIndex === 0 ? 0 : _getStaggeringFromCache({element, animationIndex, animationName, namespace}, cacheKey);
   disableTransitions(element);
   addClass(element, `${namespace}-${animationName}-prepare`);
   addClass(element, `${namespace}-${animationName}`);
   addClass(element, `${namespace}-animate`);
+
+  const cacheKey = _composeCacheKey(element);
+  const staggeringDuration = animationIndex === 0 ? 0 : _getStaggeringFromCache({element, animationIndex, animationName, namespace}, cacheKey);
+
   return new Promise((resolve) => {
     setTimeout(resolve, staggeringDuration);
   }).then(() => forceReflow(element).then(() => {

--- a/src/vanilla.js
+++ b/src/vanilla.js
@@ -42,7 +42,6 @@ export function animorph (element, {
   }
   // Turn element from a single element or a node list or an array to an array:
   const elements = isDomElement(element) ? [element] : Array.prototype.slice.call(element);
-  const elementsCount = elements.length;
   return Promise.all(elements.map((element, animationIndex) => {
     if (!isDomElement(element)) {
       throw new Error('Element is required');
@@ -57,7 +56,6 @@ export function animorph (element, {
       addClasses,
       removeClasses,
       element,
-      elementsCount,
       target,
       operation,
       morphParent


### PR DESCRIPTION
This pull-request fixes a small bug which did **not** allow different animations for _leave_ and _enter_ of the same element.

The problem is that for now the animation-classes (e.g. enter/leave) are not incorporated into the cache-key. A distinction between enter / leave is therefore not possible.

This fix creates a cache-key based on the css-classes including the animation-classes. Consequentially, the cache will distinguish between the same element entering or leaving. 